### PR TITLE
Remove the clear X on IE for search boxes

### DIFF
--- a/source/stylesheets/doi/components/_inputs.scss
+++ b/source/stylesheets/doi/components/_inputs.scss
@@ -296,6 +296,10 @@ textarea.form-control {
     text-decoration: none;
   }
 
+  input[name="query"]::-ms-clear {
+    display: none;
+  }
+
   input[name="query"] {
     z-index: 1;
     height: 45px;


### PR DESCRIPTION
This should remove the clear x from any IE11 search boxes as we have our own custom one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacite/segugio/9)
<!-- Reviewable:end -->
